### PR TITLE
Adoucit les champs de planification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/style.css
+++ b/style.css
@@ -435,21 +435,42 @@ body {
 #planifier-days input,
 #planifier-days select {
   width: 100%;
-  padding: 10px 12px;
-  border: 1px solid rgba(234, 196, 175, 0.8);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.85);
+  padding: 10px 14px;
+  border: 1.5px solid rgba(229, 187, 170, 0.9);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 246, 240, 0.95), rgba(255, 238, 232, 0.9));
   color: var(--text);
   font-family: inherit;
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 14px rgba(234, 196, 175, 0.2);
+}
+
+#planifier-days input::placeholder {
+  color: rgba(166, 128, 118, 0.65);
+}
+
+#planifier-days select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23A68076' d='M6 8 0 0h12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 12px;
+  padding-right: 38px;
 }
 
 #planifier-days input:focus,
 #planifier-days select:focus {
   outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(234, 196, 175, 0.25);
+  border-color: rgba(227, 173, 155, 1);
+  box-shadow: 0 0 0 4px rgba(234, 196, 175, 0.25);
+}
+
+#planifier-days select option {
+  background: #fff7f2;
+  color: var(--text);
 }
 
 .upload-group {


### PR DESCRIPTION
## Summary
- harmonize les champs de saisie du planificateur avec des bordures rosées arrondies et une apparence adoucie
- ajoute un style dédié aux listes déroulantes pour retirer la bordure noire et intégrer une flèche personnalisée
- ignore les répertoires et fichiers temporaires comme node_modules et dist

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e28c3f894c83329d4a147573435fe0