### PR TITLE
Add streak tracking and badge celebrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,16 @@
             <div class="progress-bar-container" id="global-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progression globale des mini-tâches">
               <div class="progress-bar" id="progress-bar"></div>
             </div>
-            <div class="momentum-ring" id="momentum-ring" aria-label="Progression des mini-tâches du jour">
-              <span class="momentum-percentage" id="momentum-percentage">0%</span>
+            <div class="momentum-row">
+              <div class="momentum-ring" id="momentum-ring" aria-label="Progression des mini-tâches du jour">
+                <span class="momentum-percentage" id="momentum-percentage">0%</span>
+              </div>
+              <div class="streak-summary" id="streak-summary" tabindex="0" aria-describedby="streak-tooltip">
+                <span class="streak-icon" aria-hidden="true">🔥</span>
+                <span class="streak-text" id="streak-text">Streak : 0 jour</span>
+                <span class="streak-badge" id="streak-badge" aria-hidden="true">—</span>
+                <span class="streak-tooltip" id="streak-tooltip" role="tooltip">Meilleur streak : 0 jour</span>
+              </div>
             </div>
             <div class="kpi-image-container">
               <img id="kpi-image-display" src="" alt="KPI" style="display:none;">
@@ -129,9 +137,22 @@
               <span class="kpi-label">Reports</span>
               <span class="kpi-value" id="weekly-reports">0 report · Motif dominant : —</span>
             </div>
-            <div class="weekly-kpi-card">
-              <span class="kpi-label">Streak actuel</span>
-              <span class="kpi-value" id="weekly-streak">0 jour</span>
+            <div class="weekly-kpi-card regularity-card">
+              <span class="kpi-label">Régularité</span>
+              <div class="regularity-metrics">
+                <div class="regularity-row">
+                  <span class="regularity-icon" aria-hidden="true">🔥</span>
+                  <span class="regularity-text" id="weekly-regularity-current">Streak actuel : 0 jour</span>
+                </div>
+                <div class="regularity-row">
+                  <span class="regularity-icon" aria-hidden="true">📈</span>
+                  <span class="regularity-text" id="weekly-regularity-best">Meilleur streak : 0 jour</span>
+                </div>
+                <div class="regularity-row">
+                  <span class="regularity-icon" id="weekly-regularity-badge-icon" aria-hidden="true">🏅</span>
+                  <span class="regularity-text" id="weekly-regularity-badge-text">Dernier badge : —</span>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -185,6 +206,8 @@
   <div id="modal-overlay" class="modal-overlay">
     <div class="modal-content" id="modal-content"></div>
   </div>
+
+  <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
 
   <canvas id="confetti-canvas"></canvas>
 

--- a/style.css
+++ b/style.css
@@ -111,6 +111,34 @@ body {
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
+.regularity-card {
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.regularity-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.regularity-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.regularity-icon {
+  font-size: 1.05rem;
+}
+
+.regularity-text {
+  font-weight: 500;
+}
+
 .kpi-label {
   font-size: 0.9rem;
   text-transform: uppercase;
@@ -320,6 +348,79 @@ body {
   font-size: 1.4rem;
   color: var(--text);
   letter-spacing: 0.5px;
+}
+
+.momentum-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.streak-summary {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 16px;
+  padding: 12px 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--text);
+  box-shadow: 0 8px 20px rgba(234, 196, 175, 0.25);
+  position: relative;
+  cursor: default;
+  min-width: 220px;
+  transition: transform 0.2s ease;
+}
+
+.streak-summary:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 4px;
+}
+
+.streak-summary .streak-icon {
+  font-size: 1.1rem;
+}
+
+.streak-summary .streak-badge {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.streak-summary .streak-tooltip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  background: var(--text);
+  color: var(--white);
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.streak-summary .streak-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--text) transparent transparent transparent;
+}
+
+.streak-summary:hover .streak-tooltip,
+.streak-summary:focus-visible .streak-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 .kpi-image-container {
@@ -809,6 +910,65 @@ body {
 
 .modal-content.template-wide {
   max-width: 860px;
+}
+
+.badge-modal-container {
+  max-width: 320px;
+}
+
+.badge-modal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+}
+
+.badge-modal h3 {
+  margin: 0;
+  color: var(--text);
+}
+
+.badge-modal p {
+  color: rgba(166, 128, 118, 0.85);
+  font-size: 0.95rem;
+}
+
+.badge-modal-icon {
+  font-size: 2.5rem;
+}
+
+.badge-modal .btn {
+  width: 100%;
+}
+
+.toast-container {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 1200;
+  pointer-events: none;
+}
+
+.toast {
+  background: var(--primary);
+  color: var(--white);
+  padding: 12px 18px;
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(234, 196, 175, 0.45);
+  font-size: 0.95rem;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: auto;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .template-library {


### PR DESCRIPTION
## Summary
- persist streak and badge metadata with a 02:00 tolerance window and helper utilities to keep the run up to date
- show the current streak, best streak, and last badge across the dashboard and weekly review, triggering celebratory toast/confetti and a badge modal at 3/3 completion
- theme the new streak line, weekly regularity card, toast, and badge modal so they blend into the existing palette

## Testing
- npm run build *(warns that `/index.html` uses a classic script tag without `type="module"`)*

------
https://chatgpt.com/codex/tasks/task_e_68e425df4d7483329a5c7e04516268f1