### PR TITLE
Add insights tab to weekly review

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,52 +118,100 @@
 
       <section id="view-hebdo" class="view">
         <div class="card card-weekly">
-          <div class="weekly-header">
-            <h2>Revue hebdo</h2>
-            <p class="weekly-subtitle">Synthèse des 7 derniers jours (J-6 → J)</p>
+          <div class="weekly-tabs" role="tablist">
+            <button type="button" class="weekly-tab weekly-tab-active" role="tab" aria-selected="true" aria-controls="weekly-panel-review" data-tab="review">Revue hebdo</button>
+            <button type="button" class="weekly-tab" role="tab" aria-selected="false" aria-controls="weekly-panel-insights" data-tab="insights">Insights</button>
           </div>
-          <div class="weekly-kpis">
-            <div class="weekly-kpi-card">
-              <span class="kpi-label">Jours 3/3</span>
-              <span class="kpi-value" id="weekly-full-days">0 / 7</span>
-              <span class="kpi-caption">planifiés</span>
+
+          <div class="weekly-panel active" id="weekly-panel-review" data-panel="review">
+            <div class="weekly-header">
+              <h2>Revue hebdo</h2>
+              <p class="weekly-subtitle">Synthèse des 7 derniers jours (J-6 → J)</p>
             </div>
-            <div class="weekly-kpi-card">
-              <span class="kpi-label">Taux de réussite</span>
-              <span class="kpi-value" id="weekly-success-rate">0%</span>
-              <span class="kpi-caption">(jours 3/3 ÷ 7)</span>
-            </div>
-            <div class="weekly-kpi-card">
-              <span class="kpi-label">Reports</span>
-              <span class="kpi-value" id="weekly-reports">0 report · Motif dominant : —</span>
-            </div>
-            <div class="weekly-kpi-card regularity-card">
-              <span class="kpi-label">Régularité</span>
-              <div class="regularity-metrics">
-                <div class="regularity-row">
-                  <span class="regularity-icon" aria-hidden="true">🔥</span>
-                  <span class="regularity-text" id="weekly-regularity-current">Streak actuel : 0 jour</span>
-                </div>
-                <div class="regularity-row">
-                  <span class="regularity-icon" aria-hidden="true">📈</span>
-                  <span class="regularity-text" id="weekly-regularity-best">Meilleur streak : 0 jour</span>
-                </div>
-                <div class="regularity-row">
-                  <span class="regularity-icon" id="weekly-regularity-badge-icon" aria-hidden="true">🏅</span>
-                  <span class="regularity-text" id="weekly-regularity-badge-text">Dernier badge : —</span>
+            <div class="weekly-kpis">
+              <div class="weekly-kpi-card">
+                <span class="kpi-label">Jours 3/3</span>
+                <span class="kpi-value" id="weekly-full-days">0 / 7</span>
+                <span class="kpi-caption">planifiés</span>
+              </div>
+              <div class="weekly-kpi-card">
+                <span class="kpi-label">Taux de réussite</span>
+                <span class="kpi-value" id="weekly-success-rate">0%</span>
+                <span class="kpi-caption">(jours 3/3 ÷ 7)</span>
+              </div>
+              <div class="weekly-kpi-card">
+                <span class="kpi-label">Reports</span>
+                <span class="kpi-value" id="weekly-reports">0 report · Motif dominant : —</span>
+              </div>
+              <div class="weekly-kpi-card regularity-card">
+                <span class="kpi-label">Régularité</span>
+                <div class="regularity-metrics">
+                  <div class="regularity-row">
+                    <span class="regularity-icon" aria-hidden="true">🔥</span>
+                    <span class="regularity-text" id="weekly-regularity-current">Streak actuel : 0 jour</span>
+                  </div>
+                  <div class="regularity-row">
+                    <span class="regularity-icon" aria-hidden="true">📈</span>
+                    <span class="regularity-text" id="weekly-regularity-best">Meilleur streak : 0 jour</span>
+                  </div>
+                  <div class="regularity-row">
+                    <span class="regularity-icon" id="weekly-regularity-badge-icon" aria-hidden="true">🏅</span>
+                    <span class="regularity-text" id="weekly-regularity-badge-text">Dernier badge : —</span>
+                  </div>
                 </div>
               </div>
             </div>
+
+            <div class="weekly-graph-card">
+              <h3>Progression quotidienne</h3>
+              <div class="weekly-graph" id="weekly-graph"></div>
+            </div>
+
+            <div class="weekly-reco-card">
+              <h3>Recommandation</h3>
+              <p id="weekly-recommendation">Rien à signaler — continue comme ça.</p>
+            </div>
           </div>
 
-          <div class="weekly-graph-card">
-            <h3>Progression quotidienne</h3>
-            <div class="weekly-graph" id="weekly-graph"></div>
-          </div>
-
-          <div class="weekly-reco-card">
-            <h3>Recommandation</h3>
-            <p id="weekly-recommendation">Rien à signaler — continue comme ça.</p>
+          <div class="weekly-panel" id="weekly-panel-insights" data-panel="insights" hidden>
+            <div class="weekly-insights-empty" id="weekly-insights-empty">Pas encore de données pour générer des insights.</div>
+            <div class="weekly-insights" id="weekly-insights-content">
+              <div class="weekly-insights-kpis">
+                <div class="insight-kpi-card">
+                  <span class="insight-label">Créneau le + fiable</span>
+                  <span class="insight-value" id="insight-best-slot">—</span>
+                </div>
+                <div class="insight-kpi-card">
+                  <span class="insight-label">Motif de report n°1</span>
+                  <span class="insight-value" id="insight-top-report">—</span>
+                </div>
+                <div class="insight-kpi-card">
+                  <span class="insight-label">Motivation moyenne</span>
+                  <span class="insight-value" id="insight-avg-motivation">—</span>
+                </div>
+                <div class="insight-kpi-card">
+                  <span class="insight-label">Humeur dominante</span>
+                  <span class="insight-value" id="insight-dominant-mood">—</span>
+                </div>
+              </div>
+              <div class="weekly-insights-charts">
+                <div class="insight-chart">
+                  <div class="insight-chart-header">
+                    <span class="insight-chart-title">Complétion quotidienne</span>
+                    <span class="insight-chart-caption">7 derniers jours</span>
+                  </div>
+                  <div class="insight-bars" id="insight-completion-bars"></div>
+                </div>
+                <div class="insight-chart">
+                  <div class="insight-chart-header">
+                    <span class="insight-chart-title">Motivation</span>
+                    <span class="insight-chart-caption">Glissant 7j</span>
+                  </div>
+                  <div class="insight-sparkline-wrapper" id="insight-motivation-sparkline"></div>
+                </div>
+              </div>
+              <p class="insight-text" id="insight-textual">Pas encore assez de recul pour un insight personnalisé.</p>
+            </div>
           </div>
         </div>
       </section>

--- a/style.css
+++ b/style.css
@@ -86,6 +86,48 @@ body {
   gap: 24px;
 }
 
+.weekly-tabs {
+  display: inline-flex;
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+}
+
+.weekly-tab {
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.weekly-tab:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.weekly-tab-active {
+  background: var(--primary);
+  color: var(--white);
+  box-shadow: 0 8px 18px rgba(234, 196, 175, 0.35);
+}
+
+.weekly-panel {
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.weekly-panel.active {
+  display: flex;
+}
+
 .weekly-header h2 {
   margin-bottom: 4px;
 }
@@ -209,6 +251,148 @@ body {
 .weekly-reco-card p {
   font-size: 1rem;
   color: var(--text);
+}
+
+.weekly-insights {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.weekly-insights[hidden] {
+  display: none;
+}
+
+.weekly-insights-kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 16px;
+}
+
+.insight-kpi-card {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+}
+
+.insight-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(166, 128, 118, 0.75);
+}
+
+.insight-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.weekly-insights-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.insight-chart {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+}
+
+.insight-chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.insight-chart-title {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.insight-chart-caption {
+  font-size: 0.8rem;
+  color: rgba(166, 128, 118, 0.7);
+}
+
+.insight-bars {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 10px;
+  align-items: end;
+  height: 120px;
+}
+
+.insight-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.insight-bar-fill {
+  width: 100%;
+  max-width: 20px;
+  border-radius: 10px 10px 6px 6px;
+  background: linear-gradient(180deg, rgba(166, 128, 118, 0.35), var(--primary));
+  transition: height 0.3s ease;
+}
+
+.insight-bar-day {
+  font-size: 0.75rem;
+  text-transform: lowercase;
+  color: rgba(166, 128, 118, 0.7);
+}
+
+.insight-sparkline-wrapper {
+  height: 80px;
+  display: flex;
+  align-items: center;
+}
+
+.insight-sparkline {
+  width: 100%;
+  height: 100%;
+}
+
+.insight-sparkline path {
+  stroke: var(--primary);
+  stroke-width: 2;
+  fill: none;
+}
+
+.insight-placeholder {
+  color: rgba(166, 128, 118, 0.6);
+  font-size: 0.95rem;
+}
+
+.insight-text {
+  font-size: 0.95rem;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.weekly-insights-empty {
+  padding: 28px;
+  text-align: center;
+  border: 1px dashed rgba(166, 128, 118, 0.3);
+  border-radius: 16px;
+  color: rgba(166, 128, 118, 0.8);
+  font-size: 0.95rem;
+}
+
+.weekly-insights-empty[hidden] {
+  display: none;
 }
 
 .view {


### PR DESCRIPTION
## Summary
- add a tab switcher in the weekly review card to expose a new Insights panel
- compute 7-day trends for completion reliability, report reasons, motivation history, and render mini charts and textual insights
- persist daily mood history so the Insights KPIs refresh automatically and show a clean empty state when no data exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43039d0e48332beb941e06997220c