### PR TITLE
Three-page Today dashboard with swipe navigation and synced page dots

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,23 @@
           </article>
         </div>
       </section>
+      <section id="view-next" class="view today-page today-page-placeholder" aria-label="Page 3">
+        <div class="today-placeholder-stack">
+          <article class="today-placeholder-card" aria-label="4 prochains jours">
+            <h2>4 prochains jours</h2>
+            <p class="today-placeholder-text">À venir : aperçu des prochains objectifs.</p>
+          </article>
+          <article class="today-placeholder-card" aria-label="Défi 7 jours">
+            <h2>Défi 7 jours</h2>
+            <p class="today-placeholder-text">Section en cours de préparation.</p>
+          </article>
+        </div>
+      </section>
     </main>
     <nav class="page-dots" aria-label="Navigation par page">
-      <span class="dot">○</span>
-      <span class="dot active">●</span>
-      <span class="dot">○</span>
+      <button class="dot active" type="button" aria-label="Aller à la page 1" aria-pressed="true">●</button>
+      <button class="dot" type="button" aria-label="Aller à la page 2" aria-pressed="false">○</button>
+      <button class="dot" type="button" aria-label="Aller à la page 3" aria-pressed="false">○</button>
     </nav>
   </div>
   <script src="today.js"></script>

--- a/style.css
+++ b/style.css
@@ -496,11 +496,55 @@ body.view-aujourdhui-active {
 }
 
 .dot {
+  border: none;
+  background: transparent;
+  padding: 0;
   color: rgba(166, 128, 118, 0.4);
+  font: inherit;
+  cursor: pointer;
 }
 
 .dot.active {
   color: rgba(166, 128, 118, 0.9);
+}
+
+.dot:focus-visible {
+  outline: 2px solid rgba(166, 128, 118, 0.5);
+  outline-offset: 4px;
+  border-radius: 999px;
+}
+
+.today-page-placeholder {
+  align-items: flex-start;
+}
+
+.today-placeholder-stack {
+  width: min(92vw, 420px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-inline: auto;
+}
+
+.today-placeholder-card {
+  background: rgba(255, 255, 255, 0.76);
+  border-radius: 24px;
+  padding: 22px 20px;
+  box-shadow: 0 22px 36px rgba(234, 196, 175, 0.28);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.today-placeholder-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--text-strong);
+}
+
+.today-placeholder-text {
+  margin: 0;
+  color: rgba(139, 106, 95, 0.8);
 }
 
 .header {

--- a/today.js
+++ b/today.js
@@ -385,11 +385,14 @@ const initSwipePager = () => {
 
   const updateDots = (index) => {
     dots.forEach((dot, dotIndex) => {
-      dot.classList.toggle('active', dotIndex === index);
+      const isActive = dotIndex === index;
+      dot.classList.toggle('active', isActive);
+      dot.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      dot.textContent = isActive ? '●' : '○';
     });
   };
 
-  const setPage = (index) => {
+  const setPage = (index, behavior = 'auto') => {
     const safeIndex = clampIndex(index);
     const target = pages[safeIndex];
     if (!target) {
@@ -397,7 +400,7 @@ const initSwipePager = () => {
     }
     pager.scrollTo({
       left: target.offsetLeft,
-      behavior: 'auto'
+      behavior
     });
     updateDots(safeIndex);
   };
@@ -415,5 +418,11 @@ const initSwipePager = () => {
     });
   });
 
-  setPage(1);
+  dots.forEach((dot, index) => {
+    dot.addEventListener('click', () => {
+      setPage(index, 'smooth');
+    });
+  });
+
+  setPage(0);
 };


### PR DESCRIPTION
### Motivation
- Turn the single-page "Aujourd’hui" area into a horizontal 3-page mobile dashboard with distinct content per page.
- Expose a placeholder for the upcoming "4 prochains jours" and "Défi 7 jours" sections to reserve space for future work.
- Make the page indicator dots interactive and synchronized with swipe/scroll position so they accurately reflect the active page.
- Ensure accessibility and keyboard/tap navigation via button-like dots and ARIA attributes.

### Description
- Added a third page section `#view-next` with placeholder cards for "4 prochains jours" and "Défi 7 jours" in `index.html`.
- Converted pager indicators to interactive `button.dot` elements with `aria-pressed` and updated their initial markup in `index.html`.
- Implemented pager logic changes in `today.js`'s `initSwipePager`: `updateDots` now sets `aria-pressed` and dot glyphs, `setPage(index, behavior)` accepts a scroll behavior, dot clicks animate to page, and the pager starts at page `0`.
- Added styling for interactive dots and placeholder page layout in `style.css` so dots are keyboard-focusable and the placeholder cards match the app style.

### Testing
- Launched a local static server with `python -m http.server 8000` which served the updated pages successfully.
- Attempted automated UI verification with a Playwright script that tried to capture screenshots of each page, but the script timed out and could not complete (selector wait / timeout failures).
- No other automated tests were run as part of this change.
- All code changes were committed to the work branch after edits and styling updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdfd628a08332a0d1eb79c8c3654f)